### PR TITLE
fix(hermes): 修复 Agent 模板丢失 + hermes CLI 不在 PATH

### DIFF
--- a/hermes-agent/.dockerignore
+++ b/hermes-agent/.dockerignore
@@ -21,7 +21,7 @@ ui-tui/packages/hermes-ink/dist/
 # Environment files
 .env
 
-*.md
+./*.md
 
 # Runtime data (bind-mounted at /opt/data; must not leak into build context)
 data/

--- a/hermes-agent/Dockerfile
+++ b/hermes-agent/Dockerfile
@@ -130,7 +130,7 @@ RUN uv pip install --no-cache-dir --no-deps -e "."
 # ---------- Runtime ----------
 ENV HERMES_WEB_DIST=/opt/hermes/hermes_cli/web_dist
 ENV HERMES_HOME=/opt/data
-ENV PATH="/opt/data/.local/bin:${PATH}"
+ENV PATH="/opt/hermes/.venv/bin:/opt/data/.local/bin:${PATH}"
 VOLUME [ "/opt/data" ]
 ENTRYPOINT [ "/usr/bin/tini", "-g", "--", "/opt/hermes/docker/entrypoint.sh" ]
 

--- a/hermes-agent/Dockerfile.bridge
+++ b/hermes-agent/Dockerfile.bridge
@@ -77,7 +77,10 @@ RUN chmod -R a+rX /opt/hermes && \
 
 ENV HERMES_WEB_DIST=/opt/hermes/hermes_cli/web_dist
 ENV HERMES_HOME=/opt/data
-ENV PATH="/opt/data/.local/bin:${PATH}"
+ENV PATH="/opt/hermes/.venv/bin:/opt/data/.local/bin:${PATH}"
+# login shell (bash -l) sources /etc/profile which hard-resets PATH;
+# re-add hermes venv for interactive/frontend terminals.
+RUN echo 'export PATH="/opt/hermes/.venv/bin:$PATH"' > /etc/profile.d/hermes.sh
 VOLUME [ "/opt/data" ]
 ENTRYPOINT [ "/opt/hermes/docker/entrypoint.sh" ]
 


### PR DESCRIPTION
## 背景

Closes #45

修复 hermes-agent 镜像的两个构建缺陷，导致新用户容器缺少系统 agent 模板、且前端终端无法使用 `hermes` 命令。

## 问题 1：Agent 模板全部丢失

### 复现

\`\`\`bash
docker run --rm nanobot-hermes-agent:latest ls /opt/hermes/deploy_copy/Agents/
# 输出为空，预期应有 main/manager/programmer/researcher/hr/doctor
\`\`\`

### 根因

\`hermes-agent/.dockerignore\` 中的 \`*.md\` 规则会**递归匹配所有子目录**下的 markdown 文件。而 \`deploy_copy/Agents/*/\` 目录下全是 \`.md\` 文件（AGENTS.md、IDENTITY.md、SOUL.md、USER.md），全部被 Docker 排除。Docker 不会为不可达文件创建空目录。

### 影响

1. 容器启动时 \`entrypoint.sh\` 的 \`sync_nanobot_packaged_agents()\` 空操作，\`profiles/\` 目录为空
2. \`hermes_agents.py\` 发现空列表后 fallback 返回一个只有 \`workspace/\` 的虚拟 agent
3. 渠道（飞书/Telegram 等）的消息路由到 \`agent:main\` 但没有对应 profile 目录
4. 新用户登录看不到预置 agent 模板

### 修复

\`\`\`diff
- *.md
+ ./*.md
\`\`\`

仅匹配根目录。

## 问题 2：hermes CLI 不在 PATH

### 现象

前端实时终端输入 \`hermes\` → \`command not found\`。

### 根因

hermes 装在 \`/opt/hermes/.venv/bin/hermes\`，但该路径未加入 PATH。且 \`deploy_docker.py\` 实际构建的是 \`Dockerfile.bridge\`（不是 \`Dockerfile\`），两个文件都需要修。另外 Debian 的 \`/etc/profile\` 会在 login shell（前端终端用的就是 \`sh -lc "bash -il"\`）中硬编码重置 PATH，所以光改 ENV PATH 不够，还需要 \`/etc/profile.d\` 兜底。

### 修复

\`\`\`diff
  # Dockerfile & Dockerfile.bridge
- ENV PATH="/opt/data/.local/bin:${PATH}"
+ ENV PATH="/opt/hermes/.venv/bin:/opt/data/.local/bin:${PATH}"

  # Dockerfile.bridge 额外补一个 profile.d 兜底（login shell）
+ RUN echo 'export PATH="/opt/hermes/.venv/bin:$PATH"' > /etc/profile.d/hermes.sh
\`\`\`

## 验证

修复后重新构建镜像，新用户容器内：
- ✅ \`/opt/hermes/deploy_copy/Agents/\` 包含 6 个 agent 模板
- ✅ \`profiles/\` 下自动同步出 main/manager/programmer/researcher/hr/doctor
- ✅ \`main\` agent 拥有完整 profile（SOUL.md + workspace/{AGENTS,IDENTITY,USER}.md + memories/USER.md + 全部子目录）
- ✅ 前端终端直接输入 \`hermes\` 可用

## 改动文件

- \`hermes-agent/.dockerignore\` — \`*.md\` → \`./*.md\`
- \`hermes-agent/Dockerfile\` — PATH 加 venv
- \`hermes-agent/Dockerfile.bridge\` — PATH 加 venv + \`/etc/profile.d/hermes.sh\` 兜底 login shell