### PR TITLE
feat(frontend): upgrade real-time terminal from text-concat to xterm.js

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.2.1",
+        "@xterm/addon-fit": "^0.11.0",
+        "@xterm/xterm": "^6.0.0",
         "lucide-react": "^0.577.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -322,7 +324,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -339,7 +340,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -356,7 +356,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -373,7 +372,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -390,7 +388,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -407,7 +404,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -424,7 +420,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -441,7 +436,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -458,7 +452,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -475,7 +468,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -492,7 +484,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -509,7 +500,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -526,7 +516,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -543,7 +532,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -560,7 +548,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -577,7 +564,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -594,7 +580,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -611,7 +596,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -628,7 +612,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -645,7 +628,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -662,7 +644,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -679,7 +660,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -696,7 +676,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -713,7 +692,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -730,7 +708,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -747,7 +724,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1025,7 +1001,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1039,7 +1014,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1053,7 +1027,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1067,7 +1040,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1081,7 +1053,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1095,7 +1066,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1109,7 +1079,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1123,7 +1092,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1137,7 +1105,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1151,7 +1118,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1165,7 +1131,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1179,7 +1144,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1193,7 +1157,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1207,7 +1170,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1221,7 +1183,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1235,7 +1196,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1249,7 +1209,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1263,7 +1222,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1277,7 +1235,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1291,7 +1248,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1305,7 +1261,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1319,7 +1274,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1333,7 +1287,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1347,7 +1300,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1361,7 +1313,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1729,7 +1680,7 @@
       "version": "24.12.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
       "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -1739,7 +1690,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2083,6 +2033,21 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
+      "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.0.0.tgz",
+      "integrity": "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==",
+      "license": "MIT",
+      "workspaces": [
+        "addons/*"
+      ]
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2395,7 +2360,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -2490,7 +2454,6 @@
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
       "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -2776,7 +2739,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -2845,7 +2807,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -4445,7 +4406,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4586,14 +4546,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -4606,7 +4564,6 @@
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
       "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4854,7 +4811,6 @@
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -5040,7 +4996,6 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -5141,7 +5096,7 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unified": {
@@ -5318,7 +5273,6 @@
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,8 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.1",
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/xterm": "^6.0.0",
     "lucide-react": "^0.577.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/frontend/src/pages/Terminal.tsx
+++ b/frontend/src/pages/Terminal.tsx
@@ -1,5 +1,8 @@
 import { useEffect, useRef, useState } from 'react'
-import { AlertCircle, Monitor, Plug, PlugZap, TerminalSquare, Trash2 } from 'lucide-react'
+import { AlertCircle, Monitor, Plug, PlugZap, Trash2 } from 'lucide-react'
+import { Terminal } from '@xterm/xterm'
+import { FitAddon } from '@xterm/addon-fit'
+import '@xterm/xterm/css/xterm.css'
 import { getAccessToken } from '../lib/api'
 
 function base64UrlDecode(value: string): string {
@@ -21,112 +24,116 @@ function getTokenSubject(token: string): string {
 }
 
 function getTerminalSessionKey(token: string): string {
-  const sub = getTokenSubject(token)
-  return `terminal:${window.location.host}:${sub}`
+  return `terminal:${window.location.host}:${getTokenSubject(token)}`
 }
 
 export default function TerminalPage() {
-  const [termConnected, setTermConnected] = useState(false)
-  const [termOutput, setTermOutput] = useState('')
-  const [termInput, setTermInput] = useState('')
   const [termCommand, setTermCommand] = useState('bash -il')
-  const [termWs, setTermWs] = useState<WebSocket | null>(null)
+  const [termConnected, setTermConnected] = useState(false)
   const [error, setError] = useState('')
-  const outputRef = useRef<HTMLDivElement | null>(null)
-  const connectingRef = useRef(false)
-
-  useEffect(() => {
-    if (!outputRef.current) return
-    outputRef.current.scrollTop = outputRef.current.scrollHeight
-  }, [termOutput])
-
-  useEffect(() => {
-    return () => {
-      if (termWs) {
-        try { termWs.close() } catch { /* ignore */ }
-      }
-    }
-  }, [termWs])
+  const containerRef = useRef<HTMLDivElement>(null)
+  const termRef = useRef<Terminal | null>(null)
+  const wsRef = useRef<WebSocket | null>(null)
+  const commandRef = useRef(termCommand)
+  commandRef.current = termCommand
 
   const connectTerminal = () => {
-    if (connectingRef.current) return
-    if (termWs && (termWs.readyState === WebSocket.OPEN || termWs.readyState === WebSocket.CONNECTING)) return
-
+    const existing = wsRef.current
+    if (existing && (existing.readyState === WebSocket.OPEN || existing.readyState === WebSocket.CONNECTING)) return
     const token = getAccessToken()
     if (!token) {
       setError('未登录或 token 已失效')
       return
     }
-
+    setError('')
     const proto = window.location.protocol === 'https:' ? 'wss' : 'ws'
-    const wsUrl = `${proto}://${window.location.host}/api/openclaw/terminal/ws?token=${encodeURIComponent(token)}`
-    const ws = new WebSocket(wsUrl)
-    const sessionKey = getTerminalSessionKey(token)
-    connectingRef.current = true
+    const ws = new WebSocket(`${proto}://${window.location.host}/api/openclaw/terminal/ws?token=${encodeURIComponent(token)}`)
+    wsRef.current = ws
 
     ws.onopen = () => {
-      connectingRef.current = false
       setTermConnected(true)
-      setTermOutput((prev) => `${prev}\n[connected] terminal websocket connected\n`)
       ws.send(JSON.stringify({
         type: 'init',
-        session_key: sessionKey,
-        command: termCommand,
+        session_key: getTerminalSessionKey(token),
+        command: commandRef.current,
       }))
     }
-
-    ws.onclose = () => {
-      connectingRef.current = false
-      setTermConnected(false)
-      setTermOutput((prev) => `${prev}\n[disconnected] terminal websocket closed\n`)
-    }
-
-    ws.onerror = () => {
-      connectingRef.current = false
-      setTermOutput((prev) => `${prev}\n[error] websocket error\n`)
-    }
-
     ws.onmessage = (evt) => {
+      const term = termRef.current
+      if (!term) return
       try {
         const msg = JSON.parse(String(evt.data))
         if (msg.type === 'output') {
-          setTermOutput((prev) => prev + String(msg.data ?? ''))
+          term.write(String(msg.data ?? ''))
         } else if (msg.type === 'session') {
-          const reused = Boolean(msg.reused)
-          const key = String(msg.session_key ?? '')
-          setTermOutput((prev) => `${prev}[session] ${key || 'unknown'} ${reused ? '(reused)' : '(new)'}\n`)
+          term.write(`\r\n[session] ${String(msg.session_key ?? '')} ${msg.reused ? '(reused)' : '(new)'}\r\n`)
         } else if (msg.type === 'started') {
-          setTermOutput((prev) => `${prev}[started] ${String(msg.command ?? '')}\n`)
+          term.write(`[started] ${String(msg.command ?? '')}\r\n`)
         } else if (msg.type === 'exit') {
-          setTermOutput((prev) => `${prev}\n[exit] code=${String(msg.code)} signal=${String(msg.signal)}\n`)
+          term.write(`\r\n[exit] code=${String(msg.code)} signal=${String(msg.signal)}\r\n`)
         } else if (msg.type === 'error') {
-          setTermOutput((prev) => `${prev}\n[error] ${String(msg.message)}\n`)
+          term.write(`\r\n[error] ${String(msg.message ?? '')}\r\n`)
         }
       } catch {
-        setTermOutput((prev) => prev + String(evt.data))
+        term.write(String(evt.data))
       }
     }
-
-    setTermWs(ws)
+    ws.onclose = () => {
+      setTermConnected(false)
+      termRef.current?.write('\r\n[disconnected] terminal websocket closed\r\n')
+    }
+    ws.onerror = () => {
+      termRef.current?.write('\r\n[error] websocket error\r\n')
+    }
   }
 
   const disconnectTerminal = () => {
-    if (!termWs) return
-    try { termWs.close() } catch { /* ignore */ }
-    connectingRef.current = false
-    setTermWs(null)
+    const ws = wsRef.current
+    if (!ws) return
+    try { ws.close() } catch { /* ignore */ }
+    wsRef.current = null
     setTermConnected(false)
   }
 
-  const sendTerminalInput = () => {
-    if (!termWs || termWs.readyState !== WebSocket.OPEN || !termInput) return
-    termWs.send(JSON.stringify({ type: 'input', data: `${termInput}\n` }))
-    setTermInput('')
-  }
-
   useEffect(() => {
-    if (!termConnected && (!termWs || termWs.readyState === WebSocket.CLOSED)) {
-      connectTerminal()
+    const container = containerRef.current
+    if (!container) return
+    const term = new Terminal({
+      fontSize: 13,
+      fontFamily: 'Menlo, Monaco, "Courier New", monospace',
+      theme: { background: '#000000', foreground: '#b5e8b5', cursor: '#b5e8b5' },
+      cursorBlink: true,
+      scrollback: 5000,
+    })
+    const fit = new FitAddon()
+    term.loadAddon(fit)
+    term.open(container)
+    termRef.current = term
+
+    // Keyboard input → PTY (arrows, enter, ctrl-c, tab, ... all flow through)
+    term.onData((data) => {
+      const ws = wsRef.current
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({ type: 'input', data }))
+      }
+    })
+
+    const doFit = () => { try { fit.fit() } catch { /* ignore */ } }
+    doFit()
+    const resizeObserver = new ResizeObserver(doFit)
+    resizeObserver.observe(container)
+    window.addEventListener('resize', doFit)
+
+    // auto-connect on mount
+    connectTerminal()
+
+    return () => {
+      resizeObserver.disconnect()
+      window.removeEventListener('resize', doFit)
+      try { wsRef.current?.close() } catch { /* ignore */ }
+      wsRef.current = null
+      term.dispose()
+      termRef.current = null
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
@@ -135,7 +142,7 @@ export default function TerminalPage() {
     <div className="flex h-[calc(100vh-7.5rem)] flex-col">
       <div className="mb-6">
         <h1 className="text-2xl font-bold text-dark-text">实时终端</h1>
-        <p className="mt-1 text-sm text-dark-text-secondary">连接用户容器并实时执行交互命令</p>
+        <p className="mt-1 text-sm text-dark-text-secondary">完整终端（xterm.js + PTY），支持方向键、Tab 补全、TUI 向导（vi/top/htop）。直接在此输入命令即可。</p>
       </div>
 
       {error && (
@@ -149,7 +156,7 @@ export default function TerminalPage() {
         <div className="px-5 py-3 border-b border-dark-border flex items-center justify-between">
           <div className="flex items-center gap-2">
             <Monitor size={16} className="text-dark-text-secondary" />
-            <h2 className="text-sm font-semibold text-dark-text">实时终端（WS + PTY）</h2>
+            <h2 className="text-sm font-semibold text-dark-text">实时终端（xterm.js + PTY）</h2>
           </div>
           <span className={`text-xs ${termConnected ? 'text-accent-green' : 'text-dark-text-secondary'}`}>
             {termConnected ? '已连接' : '未连接'}
@@ -178,38 +185,16 @@ export default function TerminalPage() {
             >
               <PlugZap size={14} /> 断开
             </button>
-          </div>
-
-          <div
-            ref={outputRef}
-            className="min-h-0 flex-1 overflow-auto whitespace-pre-wrap rounded-lg border border-dark-border bg-black p-3 font-mono text-xs text-green-200"
-          >
-            {termOutput || '等待连接...'}
-          </div>
-
-          <div className="flex items-center gap-2">
-            <TerminalSquare size={14} className="text-dark-text-secondary" />
-            <input
-              value={termInput}
-              onChange={e => setTermInput(e.target.value)}
-              onKeyDown={(e) => { if (e.key === 'Enter') sendTerminalInput() }}
-              className="flex-1 rounded-lg border border-dark-border bg-dark-bg px-3 py-2 text-sm text-dark-text focus:border-accent-blue focus:outline-none"
-              placeholder="输入命令并回车发送"
-            />
             <button
-              onClick={sendTerminalInput}
-              className="rounded-lg border border-dark-border px-3 py-2 text-xs text-dark-text-secondary hover:text-dark-text"
-            >
-              发送
-            </button>
-            <button
-              onClick={() => setTermOutput('')}
+              onClick={() => termRef.current?.clear()}
               className="inline-flex items-center gap-1 rounded-lg border border-dark-border px-3 py-2 text-xs text-dark-text-secondary hover:text-dark-text"
-              title="清空输出"
+              title="清屏"
             >
-              <Trash2 size={14} /> 清空
+              <Trash2 size={14} /> 清屏
             </button>
           </div>
+
+          <div ref={containerRef} className="min-h-0 flex-1 overflow-hidden rounded-lg border border-dark-border bg-black p-2" />
         </div>
       </section>
     </div>


### PR DESCRIPTION
## Problem

The real-time terminal page was a React state string-concatenation `<div>` with a single-line `<input>` that sent whole commands on Enter. As a result:
- Arrow keys, Tab completion, Ctrl-C all broken
- TUI apps (vi, top, htop) and curses dialogs unusable — ANSI / cursor control rendered as garbage

## Fix

Rewrite the terminal page as a real **xterm.js** terminal emulator:
- WebSocket output → `term.write()` (ANSI rendered correctly)
- `term.onData` → `ws {type:'input'}` (per-keystroke passthrough to the existing PTY — arrows / enter / ctrl-c / tab all reach the backend)
- FitAddon + ResizeObserver auto-fit
- WS ref moved `useState` → `useRef` — eliminates the re-render storm on every `onmessage` and a stale-closure bug

## Scope

- **Pure frontend**, single page (`frontend/src/pages/Terminal.tsx`)
- **Zero backend changes** — WS protocol `{type:'input'|'output', data}` and the `proxy.py` PTY passthrough are untouched
- Dependencies: `@xterm/xterm` + `@xterm/addon-fit` only
- `npm run build` verified (tsc + vite pass)

Same class as #46 / #47 — small, generic, fixes a real usability defect. Anyone using the MultiUserClaw terminal benefits.