### PR TITLE
fix(proxy): terminal workdir should be /opt/data, not empty /workspace

### DIFF
--- a/platform/app/routes/proxy.py
+++ b/platform/app/routes/proxy.py
@@ -1026,7 +1026,7 @@ def _start_hermes_terminal_socket(container_id_or_name: str, command: str):
         stderr=True,
         tty=True,
         socket=True,
-        workdir="/workspace",
+        workdir="/opt/data",
     )
     return getattr(result, "output", result[1] if isinstance(result, tuple) else result)
 


### PR DESCRIPTION
## Problem

The frontend terminal (`docker exec` PTY into the user's dedicated runtime container) starts with `workdir=/workspace`. But `/workspace` only holds `platform-runtime.json` — it's an essentially empty data volume. The user's actual files (profiles, skills, sessions, `.env`) live in `/opt/data` (HERMES_HOME). Opening the terminal drops the user into an empty directory, forcing a `cd /opt/data` every time.

## Fix

Set the terminal `workdir` to `/opt/data` so users land in their real data directory.

```diff
 def _start_hermes_terminal_socket(container_id_or_name: str, command: str):
     container = get_docker_container(container_id_or_name)
     result = container.exec_run(
         ["sh", "-lc", command],
         stdin=True,
         stdout=True,
         stderr=True,
         tty=True,
         socket=True,
-        workdir="/workspace",
+        workdir="/opt/data",
     )
```

## Verification

On a running container: `/opt/data` contains `profiles/`, `skills/`, `sessions/`, `.env`, etc.; `/workspace` contains only `platform-runtime.json`. After the fix the terminal opens in `/opt/data` and the user sees their files immediately.

One-line change, no behavior change beyond the starting directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
