### PR TITLE
fix(files): resolve workspace-relative file download 404

### DIFF
--- a/platform/app/runtime_backends/hermes_files.py
+++ b/platform/app/runtime_backends/hermes_files.py
@@ -161,6 +161,9 @@ def normalize_hermes_read_path(requested_path: str | None) -> str:
     raw = raw.removeprefix("~/.openclaw/")
     raw = raw.removeprefix("/root/.openclaw/")
     raw = raw.removeprefix("root/.openclaw/")
+    # workspace 相对路径（agent 引用 workspace/uploads/xxx）补 /，走下方 /workspace → profiles/main 映射
+    if not raw.startswith("/") and (raw.startswith("workspace") or raw.startswith("workspace-")):
+        raw = "/" + raw
     if raw.startswith("/"):
         normalized = posixpath.normpath(raw)
         if normalized == "/workspace" or normalized.startswith("/workspace/"):


### PR DESCRIPTION
## Problem

When an agent references a file it produced via a workspace-relative path (e.g. `workspace/uploads/report.md` or `~/.openclaw/workspace/uploads/report.md`), the download always 404s.

Files actually live at `/opt/data/profiles/main/workspace/...` (the agent's profile workspace). The frontend (`FileDownloadPlugin.tsx`) extracts the relative `workspace/...` path and calls `/filemanager/download?path=workspace/uploads/report.md`. But `normalize_hermes_read_path` only special-cases **absolute** `/workspace/...` (mapping it to `/opt/data/profiles/main/workspace/...`); the **relative** branch falls through to `/opt/data/{rel}` → `/opt/data/workspace/uploads/report.md`, which is an empty directory → `get_archive` 404. `_legacy_profile_fallback_path` only handles the reverse direction (`/opt/data/profiles/...` → `/opt/data/workspace-...`), so it doesn't rescue this case.

## Fix

Promote `workspace` / `workspace-` relative paths to absolute before the absolute branch, so they hit the existing `/workspace → /opt/data/profiles/main/workspace` mapping.

```diff
     raw = raw.removeprefix("~/.openclaw/")
     raw = raw.removeprefix("/root/.openclaw/")
     raw = raw.removeprefix("root/.openclaw/")
+    # workspace-relative → absolute, to hit the /workspace → profiles/main mapping below
+    if not raw.startswith("/") and (raw.startswith("workspace") or raw.startswith("workspace-")):
+        raw = "/" + raw
     if raw.startswith("/"):
```

## Verification

Before: `read_file_from_hermes_container(container, 'workspace/uploads/skill.md')` → 404.
After: same call → 4768 bytes, `text/markdown` ✓.

3 lines (incl. comment), no behavior change for other path kinds.
