### PR TITLE
fix(skills): toggle route missing + NameError on nested skill resolve

### DIFF
--- a/platform/app/api_compat/openclaw_compat.py
+++ b/platform/app/api_compat/openclaw_compat.py
@@ -26,6 +26,7 @@ from app.runtime_backends.hermes_skills import (
     delete_skill_from_hermes_container,
     download_skill_from_hermes_container,
     list_skills_from_hermes_container,
+    set_skill_disabled_in_hermes_container,
     upload_skill_zip_to_hermes_container,
 )
 from app.runtime_backends.skills_marketplace import load_recommended_skills, resolve_recommended_skill_dir
@@ -45,6 +46,10 @@ class SendMessageRequest(BaseModel):
 class SkillSearchRequest(BaseModel):
     query: str = ""
     limit: int = 10
+
+
+class SkillToggleRequest(BaseModel):
+    enabled: bool = True
 
 
 class SharedChatRequest(BaseModel):
@@ -148,6 +153,19 @@ async def download_dedicated_skill(
         content=zip_data,
         media_type="application/zip",
         headers={"Content-Disposition": f'attachment; filename="{name.rsplit("/", 1)[-1]}.zip"'},
+    )
+
+
+@router.put("/api/openclaw/skills/{name:path}/toggle")
+async def toggle_dedicated_skill(
+    name: str,
+    req: SkillToggleRequest,
+    user: User = Depends(get_current_user),
+):
+    async with async_session() as db:
+        container = await ensure_running(db, user.id)
+    return set_skill_disabled_in_hermes_container(
+        container.docker_id, name, disabled=not req.enabled
     )
 
 

--- a/platform/app/runtime_backends/hermes_skills.py
+++ b/platform/app/runtime_backends/hermes_skills.py
@@ -98,6 +98,9 @@ print(json.dumps(skills, ensure_ascii=False))
 """
 
 _RESOLVE_SKILL_SCRIPT = r"""
+import os
+from pathlib import Path
+
 def clean_scalar(value):
     value = value.strip()
     if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:


### PR DESCRIPTION
## Problem

Two bugs prevent the skill store from toggling installed skills on/off.

### 1. Toggle route never registered

The frontend calls `PUT /api/openclaw/skills/{name}/toggle` to enable/disable a skill, but **no such route exists** in the backend. The handler `set_skill_disabled_in_hermes_container` (`hermes_skills.py`) is implemented but never wired to a route. Result: `404` → the request fails → the frontend reverts the switch → toggling appears broken for **every** skill.

### 2. `NameError: Path is not defined` for nested skills

`_RESOLVE_SKILL_SCRIPT` (`hermes_skills.py`) defines `resolve_skill_dir`, which references `Path(dirpath)` inside the `os.walk` fallback branch. The script string, however, imports **neither `os` nor `pathlib.Path`** at its header. The companion snippet that gets concatenated only adds `import json, os, sys` (so `os` works) but omits `from pathlib import Path`.

Consequence:

- Skills located directly under the skills root (`/opt/data/skills/<name>`) resolve via the direct-path branch (`os.path.isdir` → `return`) and never touch `Path` → **work**.
- Skills in **nested directories** (`/opt/data/skills/<category>/<name>`, e.g. `autonomous-ai-agents/codex`) miss the direct path, fall into the `os.walk` branch, hit `Path(dirpath)` → `NameError` → `400 Bad Request`.

Because `_RESOLVE_SKILL_SCRIPT` is shared by **7** operations (`toggle`, `delete`, `download`, `list_skill_files`, `read_skill_file`, `write_skill_file`, `skill_zip`), every nested-skill operation returns 400 — not just toggle.

## Fix

1. **Register the toggle route** — add `PUT /api/openclaw/skills/{name:path}/toggle` that calls `set_skill_disabled_in_hermes_container(..., disabled=not enabled)`. The frontend sends `{ enabled: bool }`; the marker-based store is disable-oriented, hence the negation.
2. **Make `_RESOLVE_SKILL_SCRIPT` self-contained** — add `import os` and `from pathlib import Path` to the script header. One change repairs all 7 consumers.

```diff
 _RESOLVE_SKILL_SCRIPT = r"""
+import os
+from pathlib import Path
+
 def clean_scalar(value):
```

## Verification

Reproduced on a running user container with a nested skill (`autonomous-ai-agents/codex`):

- Before: `set_skill_disabled_in_hermes_container(container, "codex", disabled=False)` raises `HTTPException 400 — NameError: name 'Path' is not defined`.
- After: `disabled=False` → `{'ok': True, 'disabled': False}`; `disabled=True` → `{'ok': True, 'disabled': True}`. The `.openclaw-disabled` marker is created/removed as expected.

Top-level skills (e.g. `pptx`) worked before and after.

## Scope

- `platform/app/api_compat/openclaw_compat.py`: +18 (request model + import + toggle route)
- `platform/app/runtime_backends/hermes_skills.py`: +3 (script imports)

No behavior change for skills that already worked.
