### PR TITLE
fix(deploy_docker): correct --clean container prefix + remove NameError dead branch

### DIFF
--- a/deploy_docker.py
+++ b/deploy_docker.py
@@ -55,13 +55,8 @@ BOLD = "\033[1m"
 RESET = "\033[0m"
 
 PROJECT_DIR = os.path.dirname(os.path.abspath(__file__))
-AUTO_START_DOCKER_ENV = "NANOBOT_AUTO_START_DOCKER_DESKTOP"
 DEFAULT_APT_DEBIAN_MIRROR = "http://mirrors.ustc.edu.cn/debian"
 DEFAULT_APT_SECURITY_MIRROR = "http://mirrors.ustc.edu.cn/debian-security"
-
-
-def env_flag(name: str) -> bool:
-    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 def resolve_vite_api_url(host: str, gateway_port: int, relative_api: bool) -> str:
@@ -115,13 +110,6 @@ def check_prerequisites():
     """检查 docker 和 docker compose 是否可用。"""
     log("检查前置依赖...")
 
-    if env_flag(AUTO_START_DOCKER_ENV):
-        if not docker_result.ok:
-            error(docker_result.error or "Docker daemon 未运行，请先启动 Docker")
-            sys.exit(1)
-        if docker_result.started_desktop:
-            success("Docker Desktop 已通过 PowerShell 启动")
-
     for cmd, name in [("docker --version", "Docker"), ("docker compose version", "Docker Compose")]:
         result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
         if result.returncode != 0:
@@ -132,10 +120,7 @@ def check_prerequisites():
     # 检查 docker daemon
     result = subprocess.run("docker info", shell=True, capture_output=True, text=True)
     if result.returncode != 0:
-        error(
-            "Docker daemon 未运行，请先启动 Docker；WSL 本机场景可显式设置 "
-            f"{AUTO_START_DOCKER_ENV}=1 后再运行"
-        )
+        error("Docker daemon 未运行，请先启动 Docker")
         sys.exit(1)
     success("Docker daemon 运行中")
 
@@ -379,7 +364,7 @@ def clean_all(compose_file: str):
 
     log("清理用户容器...")
     result = subprocess.run(
-        'docker ps -a --filter "name=openclaw-user-" -q',
+        'docker ps -a --filter "name=hermes-user-" -q',
         shell=True, capture_output=True, text=True, cwd=PROJECT_DIR,
     )
     container_ids = result.stdout.strip()


### PR DESCRIPTION
## 问题

`deploy_docker.py` 里有两个 bug：

### 1. `--clean` 容器名前缀错误，清不掉任何容器

`--clean` 用 `openclaw-user-` 作为 `docker ps` 的 name 过滤前缀：

```python
# deploy_docker.py (旧)
'docker ps -a --filter "name=openclaw-user-" -q',
```

但 `platform/app/config.py` 默认 `dedicated_runtime_container_name_prefix="hermes-user"`，实际容器名是 `hermes-user-<uid8>`。两者前缀不一致，`--clean` 永远匹配不到任何容器，等于失效。

### 2. `NANOBOT_AUTO_START_DOCKER_DESKTOP=1` 必然 NameError

`check_prerequisites` 里有一段死分支：

```python
# deploy_docker.py (旧, 118-123)
if env_flag(AUTO_START_DOCKER_ENV):
    if not docker_result.ok:              # docker_result 未定义
        error(docker_result.error or ...)
        sys.exit(1)
    if docker_result.started_desktop:
        success("Docker Desktop 已通过 PowerShell 启动")
```

`docker_result` 在整个文件里没有任何赋值，只是这段被 `env_flag(...)` 守着。只要设了 `NANOBOT_AUTO_START_DOCKER_DESKTOP=1` 进这个分支就会抛 `NameError: name 'docker_result' is not defined`，部署必然失败。

## 修复

- `--clean` 过滤前缀改为 `hermes-user-`，和 `config.py` 默认前缀对齐。
- 删除引用未定义 `docker_result` 的死分支，连同无调用方的 `AUTO_START_DOCKER_ENV` 常量、`env_flag` 辅助函数，以及 daemon 错误提示里对该环境变量的引用一并清理。

## 验证

- `python3 -m py_compile deploy_docker.py` 通过
- `grep -n 'openclaw-user-\|docker_result\|AUTO_START_DOCKER\|env_flag' deploy_docker.py` 无残留