### PR TITLE
fix(feishu): drop stale table→text downgrade now that post md supports GFM tables

### DIFF
--- a/hermes-agent/plugins/platforms/feishu/adapter.py
+++ b/hermes-agent/plugins/platforms/feishu/adapter.py
@@ -155,7 +155,8 @@ _MARKDOWN_HINT_RE = re.compile(
     re.MULTILINE,
 )
 # Detect markdown tables: a line starting with | followed by a separator line.
-# Feishu post-type 'md' elements do not render tables, so we force text mode.
+# Kept so that table-bearing content (which _MARKDOWN_HINT_RE may not catch) is
+# still routed into post+md rendering, which now supports GFM tables.
 _MARKDOWN_TABLE_RE = re.compile(r"^\|.*\|\n\|[-|: ]+\|", re.MULTILINE)
 _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 _MARKDOWN_FENCE_OPEN_RE = re.compile(r"^```([^\n`]*)\s*$")
@@ -4375,13 +4376,10 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        # Feishu post-type 'md' elements do not render markdown tables; sending
-        # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
-        if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
-        if _MARKDOWN_HINT_RE.search(content):
+        # Feishu post-type 'md' elements support GFM tables (CommonMark 0.31),
+        # so table content renders fine inside a post. Route any markdown
+        # (tables included) to post instead of downgrading the whole message.
+        if _MARKDOWN_HINT_RE.search(content) or _MARKDOWN_TABLE_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}
         return "text", json.dumps(text_payload, ensure_ascii=False)


### PR DESCRIPTION
## Problem

When a markdown table appeared in an outbound message, `_build_outbound_payload()` in `hermes-agent/plugins/platforms/feishu/adapter.py` forced the **entire** message down to plain `text`. As a result, every other piece of rich formatting in that chunk — headings, bold, italic, lists, code blocks/fences, inline code, links — was also stripped, leaving the user with bare text plus raw table pipe syntax.

## Root cause

The downgrade was gated on this assumption (quoted from the old comment):

> Feishu post-type 'md' elements do not render markdown tables; sending table content as post causes the message to appear blank on the client.

That assumption is stale. Feishu post `md` rendering follows CommonMark 0.31 + GFM and renders tables natively, so the table-only `text` downgrade is no longer needed — and its side effect of discarding all sibling formatting is worse than the problem it was trying to solve.

## Fix

Remove the table-specific `text` downgrade branch and route table-bearing content through the normal `post` + `md` path. The table regex is folded into the existing markdown-hint check so chunks that contain *only* a table (and would otherwise not match `_MARKDOWN_HINT_RE`) are still captured and rendered via `post`.

The `_MARKDOWN_TABLE_RE` regex is retained (its stale "force text mode" comment is updated) — it now exists to ensure table content reaches the post renderer.

```diff
 def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-    # Feishu post-type 'md' elements do not render markdown tables; sending
-    # table content as post causes the message to appear blank on the client.
-    # Force plain text for anything that looks like a markdown table.
-    if _MARKDOWN_TABLE_RE.search(content):
-        text_payload = {"text": content}
-        return "text", json.dumps(text_payload, ensure_ascii=False)
-    if _MARKDOWN_HINT_RE.search(content):
+    # Feishu post-type 'md' elements support GFM tables (CommonMark 0.31),
+    # so table content renders fine inside a post. Route any markdown
+    # (tables included) to post instead of downgrading the whole message.
+    if _MARKDOWN_HINT_RE.search(content) or _MARKDOWN_TABLE_RE.search(content):
         return "post", _build_markdown_post_payload(content)
     text_payload = {"text": content}
     return "text", json.dumps(text_payload, ensure_ascii=False)
```

## Scope

Pure Feishu adapter bugfix — single function, no new dependencies, no API surface change. Non-table content is unaffected (it still matches `_MARKDOWN_HINT_RE` and goes to `post` exactly as before).

## Verification

- `python3 -m py_compile` passes on the modified file.
- Confirmed via grep that the only remaining `return "text"` is the final fallback, the table downgrade branch is gone, and `_MARKDOWN_TABLE_RE` is still defined and used in the post-routing condition.