### PR TITLE
fix(llm_proxy): remove duplicate audit_log writes in proxy_chat_completion

### DIFF
--- a/platform/app/llm_proxy/service.py
+++ b/platform/app/llm_proxy/service.py
@@ -767,18 +767,8 @@ async def proxy_chat_completion(
                             output_tokens=total_output,
                             stream=True,
                         )
-                        await write_audit_log(
-                            db,
-                            action="llm_call",
-                            user_id=user.id,
-                            resource=model,
-                            detail={
-                                "stream": True,
-                                "input_tokens": total_input,
-                                "output_tokens": total_output,
-                                "total_tokens": total,
-                            },
-                        )
+                        # audit_log is written once inside _record_usage (with provider_id/upstream_model).
+                        # The previous duplicate write_audit_log here created 2 llm_call records per call.
                         await db.commit()
                     except Exception as e:
                         logger.warning("Failed to record streaming usage: %s", e)
@@ -798,18 +788,8 @@ async def proxy_chat_completion(
             output_tokens=usage.completion_tokens or 0,
             stream=False,
         )
-        await write_audit_log(
-            db,
-            action="llm_call",
-            user_id=user.id,
-            resource=model,
-            detail={
-                "stream": False,
-                "input_tokens": usage.prompt_tokens or 0,
-                "output_tokens": usage.completion_tokens or 0,
-                "total_tokens": usage.total_tokens or 0,
-            },
-        )
+        # audit_log is written once inside _record_usage (with provider_id/upstream_model).
+        # The previous duplicate write_audit_log here created 2 llm_call records per call.
         await db.commit()
 
     # 7. Update container last_active_at

--- a/platform/tests/test_llm_proxy.py
+++ b/platform/tests/test_llm_proxy.py
@@ -223,3 +223,59 @@ async def test_proxy_does_not_add_reasoning_effort_when_thinking_is_explicit(mon
 
     assert "reasoning_effort" not in captured_kwargs
     assert captured_kwargs["thinking"] == {"type": "enabled", "budget_tokens": 1024}
+
+
+@pytest.mark.asyncio
+async def test_successful_litellm_call_writes_audit_log_exactly_once(monkeypatch):
+    """A successful non-streaming LiteLLM call writes the llm_call audit_log exactly once.
+
+    _record_usage writes audit_log internally; the outer call site previously wrote a
+    second, duplicate record. After removing the duplicate, write_audit_log is called
+    exactly once per LLM call.
+    """
+    monkeypatch.setattr(service.settings, "dev_openclaw_url", "")  # real auth path -> reach user lookup
+    monkeypatch.setattr(service.settings, "hermes_reasoning_effort", "none")
+    monkeypatch.setattr(service.settings, "hermes_service_tier", "")
+    monkeypatch.setattr(
+        service,
+        "_resolve_provider",
+        lambda _model: ("openai/gpt-5.4", "openai-key", None, None),
+    )
+    monkeypatch.setattr(service, "_litellm_model_supports_param", lambda *args: True)
+
+    # Real auth chain: decode_token -> valid payload, db.execute -> fake user
+    monkeypatch.setattr(service, "decode_token", lambda _t: {"type": "access", "sub": "u1"})
+    monkeypatch.setattr(service, "_check_quota", AsyncMock())
+
+    fake_user = SimpleNamespace(id="u1", is_active=True)
+    db = AsyncMock()
+    user_result = SimpleNamespace(scalar_one_or_none=lambda: fake_user)
+    container_result = SimpleNamespace(scalar_one_or_none=lambda: None)
+    db.execute = AsyncMock(side_effect=[user_result, container_result])
+    db.add = lambda _obj: None  # _record_usage internally does db.add(UsageRecord(...))
+
+    async def fake_acompletion(**kwargs):
+        return SimpleNamespace(
+            model_dump=lambda: {"ok": True},
+            usage=SimpleNamespace(prompt_tokens=10, completion_tokens=20, total_tokens=30),
+        )
+
+    monkeypatch.setattr(service, "acompletion", fake_acompletion)
+
+    audit_calls = []
+    monkeypatch.setattr(
+        service, "write_audit_log",
+        AsyncMock(side_effect=lambda *a, **k: audit_calls.append(k)),
+    )
+
+    await service.proxy_chat_completion(
+        db=db,
+        container_token="jwt-token",
+        raw_request={
+            "model": "openai/gpt-5.4",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": False,
+        },
+    )
+
+    assert len(audit_calls) == 1, f"audit_log should be written exactly once, got {len(audit_calls)} (duplicate-write bug)"


### PR DESCRIPTION
## Problem

In `proxy_chat_completion`, both the streaming branch (inside `_stream_generator`'s `finally` block) and the non-streaming branch called `write_audit_log(action="llm_call")` immediately after `_record_usage(...)`. However, `_record_usage` **already writes the same `llm_call` audit_log internally** (at `service.py:557`, with richer `detail` including `provider_id` and `upstream_model`).

Result: **every LiteLLM call produced 2 `llm_call` audit_log records**, doubling usage/accounting and audit-trail entries.

## Root cause

The two outer `write_audit_log(...)` call sites duplicate the write that `_record_usage` performs:

```python
await _record_usage(...)            # writes llm_call audit_log internally (line 557)
await write_audit_log(..., "llm_call", ...)   # duplicate outer write
await db.commit()
```

## Fix

Remove the two outer `write_audit_log(...) + db.commit()` call sites (streaming + non-streaming). The single write inside `_record_usage` is retained, so exactly one `llm_call` audit_log record is produced per LLM call.

## Why this is generic (not fork-specific)

`llm_proxy` is the shared LiteLLM proxy layer used by all deployments. The duplicate write affects any upstream user of this layer, independent of any downstream customizations.

## Test

Added a regression test `test_successful_litellm_call_writes_audit_log_exactly_once` that monkeypatches `write_audit_log` and asserts it is called exactly once for a successful non-streaming call (previously 2).

## Files changed

- `platform/app/llm_proxy/service.py` — removed 2 duplicate outer `write_audit_log` calls (streaming + non-streaming branches of `proxy_chat_completion`); kept the single write inside `_record_usage`.
- `platform/tests/test_llm_proxy.py` — added regression test.