### PR TITLE
fix(feishu): ignore @所有人/@everyone mentions in group chats

### DIFF
--- a/hermes-agent/plugins/platforms/feishu/adapter.py
+++ b/hermes-agent/plugins/platforms/feishu/adapter.py
@@ -4183,10 +4183,9 @@ class FeishuAdapter(BasePlatformAdapter):
     # --- Mention detection ----------------------------------------------------
 
     def _mentions_self(self, message: Any) -> bool:
-        # @_all is Feishu's @everyone placeholder.
+        # Fix #33723: @_all (@everyone) no longer treated as self-mention —
+        # stops the bot replying to every @所有人 group announcement. (@Mason-zy)
         raw_content = getattr(message, "content", "") or ""
-        if "@_all" in raw_content:
-            return True
         mentions = getattr(message, "mentions", None) or []
         if mentions and self._message_mentions_bot(mentions):
             return True


### PR DESCRIPTION
Backport of upstream NousResearch/hermes-agent#59347 (issue [#33723](https://github.com/NousResearch/hermes-agent/issues/33723)).

## Problem
In Feishu group chats, the bot replies to every `@所有人` (`@everyone`) announcement, even when not explicitly mentioned.

## Root cause
`_mentions_self()` in `hermes-agent/plugins/platforms/feishu/adapter.py` returns True for any message containing `@_all` (Feishu's `@everyone` placeholder), bypassing the `require_mention` gate.

## Fix
Drop the `@_all → return True` branch. The other two mention paths (`_message_mentions_bot` by ID, `_post_mentions_bot` by `is_self`) do not match `@everyone`, so real `@bot` mentions are unaffected.

| Message | Before | After |
|---|---|---|
| `@所有人 review please` | replies | ignored |
| `@botname hey` | replies | replies |