### PR TITLE
fix(gateway): fall back to self.config for home-channel prompt

### DIFF
--- a/hermes-agent/gateway/run.py
+++ b/hermes-agent/gateway/run.py
@@ -10025,7 +10025,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not history and source.platform and source.platform != Platform.LOCAL and source.platform != Platform.WEBHOOK:
             platform_name = source.platform.value
             env_key = _home_target_env_var(platform_name)
-            if not os.getenv(env_key):
+            # Fix #10581: /sethome persists to .env + self.config, but .env only
+            # enters os.environ after a restart, so os.getenv() missed it and the
+            # "No home channel" prompt refired every new session. Fall back to
+            # self.config (updated immediately by sethome). (@Mason-zy)
+            _home_set = bool(os.getenv(env_key))
+            if not _home_set:
+                _pcfg = None
+                try:
+                    _pcfg = self.config.platforms.get(source.platform)
+                except Exception:
+                    _pcfg = None
+                if _pcfg and getattr(_pcfg, "home_channel", None):
+                    _home_set = True
+            if not _home_set:
                 # Slack dispatches all Hermes commands through a single
                 # parent slash command `/hermes`; bare `/sethome` is not
                 # registered and would fail with "app did not respond".


### PR DESCRIPTION
Backport of upstream NousResearch/hermes-agent#59348 (issue [#10581](https://github.com/NousResearch/hermes-agent/issues/10581)).

## Problem
The "📬 No home channel is set..." prompt refires on every new session even after `/sethome` is run (until a gateway restart).

## Root cause
The prompt check in `hermes-agent/gateway/run.py` only reads `os.getenv(env_key)`, but `/sethome` writes to `.env` + `self.config` — `os.environ` only picks up the `.env` value on restart, so the in-memory `self.config` (updated immediately by `/sethome`) is ignored.

## Fix
Fall back to `self.config.platforms[platform].home_channel` before deciding to show the prompt. Stops the repeat prompt without requiring a restart.