### PR TITLE
fix(container): recognize Hermes s6 main-wrapper runtime

### DIFF
--- a/platform/app/container/manager.py
+++ b/platform/app/container/manager.py
@@ -186,7 +186,10 @@ def _container_matches_runtime(container: docker.models.containers.Container) ->
     if _runtime_backend() == "hermes":
         return (
             "API_SERVER_ENABLED=true" in env
-            and "/opt/hermes/docker/entrypoint.sh" in entrypoint
+            and (
+                "/opt/hermes/docker/entrypoint.sh" in entrypoint
+                or "/opt/hermes/docker/main-wrapper.sh" in entrypoint
+            )
             and "gateway" in command
         )
 

--- a/platform/tests/test_dedicated_container_manager.py
+++ b/platform/tests/test_dedicated_container_manager.py
@@ -263,8 +263,19 @@ def test_hermes_runtime_rejects_legacy_openclaw_container(monkeypatch):
             }
         }
     )
+    hermes_s6 = SimpleNamespace(
+        attrs={
+            "Config": {
+                "Image": "nanobot-hermes-agent:latest",
+                "Entrypoint": ["/init", "/opt/hermes/docker/main-wrapper.sh"],
+                "Cmd": ["gateway", "run", "-v"],
+                "Env": ["API_SERVER_ENABLED=true", "HERMES_HOME=/opt/data"],
+            }
+        }
+    )
 
     monkeypatch.setattr(manager.settings, "dedicated_runtime_backend", "hermes")
 
     assert manager._container_matches_runtime(legacy) is False
     assert manager._container_matches_runtime(hermes) is True
+    assert manager._container_matches_runtime(hermes_s6) is True


### PR DESCRIPTION
## Summary
- Accept `/opt/hermes/docker/main-wrapper.sh` as a valid Hermes container entrypoint.
- Keep compatibility with the older `/opt/hermes/docker/entrypoint.sh` path.
- Add focused coverage so upgraded s6-based containers are not misclassified and recreated.

## Tests
- `pytest platform/tests/test_dedicated_container_manager.py`

@Mason-zy