### PR TITLE
fix(hermes): load nanobot compatibility layer from hermes command

### DIFF
--- a/hermes-agent/pyproject.toml
+++ b/hermes-agent/pyproject.toml
@@ -294,12 +294,12 @@ all = [
 ]
 
 [project.scripts]
-hermes = "hermes_cli.main:main"
+hermes = "nanobot_hermes:main"
 hermes-agent = "run_agent:main"
 hermes-acp = "acp_adapter.entry:main"
 
 [tool.setuptools]
-py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajectory_compressor", "toolset_distributions", "cli", "hermes_bootstrap", "hermes_constants", "hermes_state", "hermes_time", "hermes_logging", "utils", "mcp_serve"]
+py-modules = ["nanobot_hermes", "run_agent", "model_tools", "toolsets", "batch_runner", "trajectory_compressor", "toolset_distributions", "cli", "hermes_bootstrap", "hermes_constants", "hermes_state", "hermes_time", "hermes_logging", "utils", "mcp_serve"]
 
 [tool.setuptools.data-files]
 # i18n catalogs. locales/ is a bare data directory (no __init__.py), so it is


### PR DESCRIPTION
## Summary
- Point the `hermes` console script at `nanobot_hermes:main`.
- Include `nanobot_hermes` in `py-modules` so the wrapper is installed with the package.
- Ensures s6 `main-wrapper.sh` launches still install the Nanobot compatibility overlay before entering Hermes CLI.

## Tests
- `python3 - <<'PY'` pyproject metadata check for `project.scripts.hermes == nanobot_hermes:main` and `nanobot_hermes` in `py-modules`

@Mason-zy