### PR TITLE
fix(container): expose persistent user CLIs on PATH

### DIFF
--- a/hermes-agent/Dockerfile
+++ b/hermes-agent/Dockerfile
@@ -355,7 +355,10 @@ ENV HERMES_LAZY_INSTALL_TARGET=/opt/data/lazy-packages
 # shim wins PATH resolution. The shim's last act is to exec the venv
 # binary by absolute path, so this PATH ordering is transparent to
 # every other consumer.
-ENV PATH="/opt/hermes/bin:/opt/hermes/.venv/bin:/opt/data/.local/bin:${PATH}"
+ENV PATH="/opt/hermes/bin:/opt/hermes/.venv/bin:/opt/data/.npm-global/bin:/opt/data/.local/bin:${PATH}"
+# Debian login shells reset PATH in /etc/profile, so restore the runtime
+# CLI paths used by the frontend terminal (bash -il).
+RUN echo 'export PATH="/opt/hermes/bin:/opt/hermes/.venv/bin:/opt/data/.npm-global/bin:/opt/data/.local/bin:$PATH"' > /etc/profile.d/hermes.sh
 RUN mkdir -p /opt/data
 VOLUME [ "/opt/data" ]
 

--- a/hermes-agent/Dockerfile
+++ b/hermes-agent/Dockerfile
@@ -355,10 +355,10 @@ ENV HERMES_LAZY_INSTALL_TARGET=/opt/data/lazy-packages
 # shim wins PATH resolution. The shim's last act is to exec the venv
 # binary by absolute path, so this PATH ordering is transparent to
 # every other consumer.
-ENV PATH="/opt/hermes/bin:/opt/hermes/.venv/bin:/opt/data/.npm-global/bin:/opt/data/.local/bin:${PATH}"
+ENV PATH="/opt/hermes/bin:/opt/hermes/.venv/bin:/opt/data/.npm-global/bin:/opt/data/bin:/opt/data/.local/bin:${PATH}"
 # Debian login shells reset PATH in /etc/profile, so restore the runtime
 # CLI paths used by the frontend terminal (bash -il).
-RUN echo 'export PATH="/opt/hermes/bin:/opt/hermes/.venv/bin:/opt/data/.npm-global/bin:/opt/data/.local/bin:$PATH"' > /etc/profile.d/hermes.sh
+RUN echo 'export PATH="/opt/hermes/bin:/opt/hermes/.venv/bin:/opt/data/.npm-global/bin:/opt/data/bin:/opt/data/.local/bin:$PATH"' > /etc/profile.d/hermes.sh
 RUN mkdir -p /opt/data
 VOLUME [ "/opt/data" ]
 

--- a/hermes-agent/Dockerfile.bridge
+++ b/hermes-agent/Dockerfile.bridge
@@ -81,10 +81,10 @@ RUN chmod -R a+rX /opt/hermes && \
 
 ENV HERMES_WEB_DIST=/opt/hermes/hermes_cli/web_dist
 ENV HERMES_HOME=/opt/data
-ENV PATH="/opt/hermes/.venv/bin:/opt/data/.local/bin:${PATH}"
+ENV PATH="/opt/hermes/.venv/bin:/opt/data/.npm-global/bin:/opt/data/.local/bin:${PATH}"
 # login shell (bash -l) sources /etc/profile which hard-resets PATH;
-# re-add hermes venv for interactive/frontend terminals.
-RUN echo 'export PATH="/opt/hermes/.venv/bin:$PATH"' > /etc/profile.d/hermes.sh
+# re-add persistent user CLI paths for interactive/frontend terminals.
+RUN echo 'export PATH="/opt/hermes/.venv/bin:/opt/data/.npm-global/bin:/opt/data/.local/bin:$PATH"' > /etc/profile.d/hermes.sh
 VOLUME [ "/opt/data" ]
 ENTRYPOINT [ "/opt/hermes/docker/entrypoint.sh" ]
 

--- a/hermes-agent/Dockerfile.bridge
+++ b/hermes-agent/Dockerfile.bridge
@@ -81,10 +81,10 @@ RUN chmod -R a+rX /opt/hermes && \
 
 ENV HERMES_WEB_DIST=/opt/hermes/hermes_cli/web_dist
 ENV HERMES_HOME=/opt/data
-ENV PATH="/opt/hermes/.venv/bin:/opt/data/.npm-global/bin:/opt/data/.local/bin:${PATH}"
+ENV PATH="/opt/hermes/.venv/bin:/opt/data/.npm-global/bin:/opt/data/bin:/opt/data/.local/bin:${PATH}"
 # login shell (bash -l) sources /etc/profile which hard-resets PATH;
 # re-add persistent user CLI paths for interactive/frontend terminals.
-RUN echo 'export PATH="/opt/hermes/.venv/bin:/opt/data/.npm-global/bin:/opt/data/.local/bin:$PATH"' > /etc/profile.d/hermes.sh
+RUN echo 'export PATH="/opt/hermes/.venv/bin:/opt/data/.npm-global/bin:/opt/data/bin:/opt/data/.local/bin:$PATH"' > /etc/profile.d/hermes.sh
 VOLUME [ "/opt/data" ]
 ENTRYPOINT [ "/opt/hermes/docker/entrypoint.sh" ]
 

--- a/hermes-agent/tests/test_dockerfile_persistent_cli_path.py
+++ b/hermes-agent/tests/test_dockerfile_persistent_cli_path.py
@@ -8,6 +8,7 @@ import pytest
 HERMES_ROOT = Path(__file__).resolve().parent.parent
 PERSISTENT_CLI_PATHS = (
     "/opt/data/.npm-global/bin",
+    "/opt/data/bin",
     "/opt/data/.local/bin",
 )
 

--- a/hermes-agent/tests/test_dockerfile_persistent_cli_path.py
+++ b/hermes-agent/tests/test_dockerfile_persistent_cli_path.py
@@ -1,0 +1,36 @@
+"""Regression coverage for persistent user-installed CLI discovery."""
+
+from pathlib import Path
+
+import pytest
+
+
+HERMES_ROOT = Path(__file__).resolve().parent.parent
+PERSISTENT_CLI_PATHS = (
+    "/opt/data/.npm-global/bin",
+    "/opt/data/.local/bin",
+)
+
+
+@pytest.mark.parametrize("dockerfile_name", ("Dockerfile", "Dockerfile.bridge"))
+def test_dockerfile_exposes_persistent_cli_paths(dockerfile_name: str) -> None:
+    dockerfile = (HERMES_ROOT / dockerfile_name).read_text(encoding="utf-8")
+    env_path = next(
+        line for line in dockerfile.splitlines() if line.startswith("ENV PATH=")
+    )
+
+    for path in PERSISTENT_CLI_PATHS:
+        assert path in env_path
+
+
+@pytest.mark.parametrize("dockerfile_name", ("Dockerfile", "Dockerfile.bridge"))
+def test_login_shell_restores_persistent_cli_paths(dockerfile_name: str) -> None:
+    dockerfile = (HERMES_ROOT / dockerfile_name).read_text(encoding="utf-8")
+    profile_setup = next(
+        line
+        for line in dockerfile.splitlines()
+        if "/etc/profile.d/hermes.sh" in line
+    )
+
+    for path in PERSISTENT_CLI_PATHS:
+        assert path in profile_setup


### PR DESCRIPTION
## Problem

User-installed CLIs persist under two durable locations:

- `/opt/data/.npm-global/bin` for npm global installs.
- `/opt/data/bin` for legacy/direct binary installs.

The published Hermes image included neither location in `PATH`. The CLI therefore survived container recreation yet remained undiscoverable, causing repeated installs to end in `command not found`.

The frontend terminal adds a second failure mode: it starts `bash -il`, and Debian `/etc/profile` resets the Docker image PATH. Updating only `ENV PATH` would fix agent subprocesses but still leave login-shell terminals unable to discover persisted CLIs.

## Fix

- Add both persistent CLI directories to the runtime PATH in `Dockerfile` and `Dockerfile.bridge`.
- Prefer `.npm-global/bin`, then fall back to legacy `/opt/data/bin`, then `.local/bin`.
- Restore the Hermes venv and persistent user CLI directories through `/etc/profile.d/hermes.sh` for login shells.
- Add regression coverage for both Dockerfile variants and both PATH entry points.

## Validation

- `pytest -q tests/test_dockerfile_persistent_cli_path.py tests/test_dockerfile_tini_compat_shim.py`: 7 passed.
- `ruff check tests/test_dockerfile_persistent_cli_path.py`: passed.
- `docker buildx build --check --file hermes-agent/Dockerfile hermes-agent`: passed with no warnings.
- Debian 13.4 login-shell probe restored both persistent CLI directories in the effective PATH.

@Mason-zy