### PR TITLE
fix(hermes): add archive tools (unzip/file/p7zip-full) to container image

### DIFF
--- a/hermes-agent/Dockerfile
+++ b/hermes-agent/Dockerfile
@@ -38,7 +38,7 @@ RUN if [ -n "${APT_DEBIAN_MIRROR}" ]; then \
     fi && \
     apt-get -o Acquire::Retries=5 -o Acquire::Queue-Mode=access -o Acquire::http::Pipeline-Depth=0 update && \
     apt-get -o Acquire::Retries=5 -o Acquire::Queue-Mode=access -o Acquire::http::Pipeline-Depth=0 install -y --no-install-recommends \
-    ca-certificates curl iputils-ping python3 python-is-python3 ripgrep ffmpeg gcc g++ make cmake python3-dev python3-venv libffi-dev libolm-dev procps git openssh-client docker-cli xz-utils && \
+    ca-certificates curl iputils-ping python3 python-is-python3 ripgrep ffmpeg gcc g++ make cmake python3-dev python3-venv libffi-dev libolm-dev procps git openssh-client docker-cli xz-utils unzip file p7zip-full && \
     rm -rf /var/lib/apt/lists/*
 
 # ---------- s6-overlay install ----------


### PR DESCRIPTION
## Problem

The Hermes agent frequently needs to extract or inspect archive files (zip/7z uploads, downloaded artifacts), but the base image lacks `unzip`, `file`, and `p7zip-full`, so these operations fail with "command not found".

## Fix

Add `unzip file p7zip-full` to the base image apt install list, alongside the existing `xz-utils`.

## Validation

- `docker buildx build --check --file hermes-agent/Dockerfile hermes-agent`: Check complete, no warnings found.
- `unzip` / `file` / `p7zip-full` are standard Debian 13 (trixie) packages.

@Mason-zy
