### PR TITLE
fix(manage-front): clamp pagination totalPages to a minimum of 1

### DIFF
--- a/manage_front/src/app/(admin)/audit/page.tsx
+++ b/manage_front/src/app/(admin)/audit/page.tsx
@@ -37,7 +37,9 @@ export default function AuditPage() {
 
   useEffect(() => { fetchData(); }, [fetchData]);
 
-  const totalPages = data ? Math.ceil(data.total / 20) : 0;
+  // Clamp totalPages to at least 1: with total=0 the old expression yielded 0,
+  // showing "1 / 0" and breaking the page >= totalPages next-button boundary.
+  const totalPages = data ? Math.max(1, Math.ceil(data.total / 20)) : 1;
 
   return (
     <div>
@@ -96,7 +98,7 @@ export default function AuditPage() {
             <p className="text-sm text-gray-500">共 {data?.total ?? 0} 条记录</p>
             <div className="space-x-2">
               <Button size="sm" variant="outline" disabled={page <= 1} onClick={() => setPage(page - 1)}>上一页</Button>
-              <span className="text-sm">{page} / {totalPages || 1}</span>
+              <span className="text-sm">{page} / {totalPages}</span>
               <Button size="sm" variant="outline" disabled={page >= totalPages} onClick={() => setPage(page + 1)}>下一页</Button>
             </div>
           </div>

--- a/manage_front/src/app/(admin)/containers/page.tsx
+++ b/manage_front/src/app/(admin)/containers/page.tsx
@@ -75,7 +75,9 @@ export default function ContainersPage() {
     }
   };
 
-  const totalPages = data ? Math.ceil(data.total / 20) : 0;
+  // Clamp totalPages to at least 1: with total=0 the old expression yielded 0,
+  // showing "1 / 0" and breaking the page >= totalPages next-button boundary.
+  const totalPages = data ? Math.max(1, Math.ceil(data.total / 20)) : 1;
 
   return (
     <div>

--- a/manage_front/src/app/(admin)/users/page.tsx
+++ b/manage_front/src/app/(admin)/users/page.tsx
@@ -132,7 +132,9 @@ export default function UsersPage() {
     }
   }
 
-  const totalPages = data ? Math.ceil(data.total / 20) : 0;
+  // Clamp totalPages to at least 1: with total=0 the old expression yielded 0,
+  // showing "1 / 0" and breaking the page >= totalPages next-button boundary.
+  const totalPages = data ? Math.max(1, Math.ceil(data.total / 20)) : 1;
 
   return (
     <div>


### PR DESCRIPTION
## Problem

The users / containers / audit admin pages compute `totalPages = data ? Math.ceil(data.total / 20) : 0`. When `total` is 0, `totalPages` becomes 0, so the pager renders "1 / 0" and the `page >= totalPages` next-button boundary is wrong. The audit page carried an inconsistent `|| 1` display patch for this.

## Fix

Clamp `totalPages` to a minimum of 1 on all three pages: `data ? Math.max(1, Math.ceil(data.total / 20)) : 1`. Empty lists now show "1 / 1" and the next button disables correctly; pages with data behave exactly as before. Also drop the now-redundant `|| 1` in the audit display.

## Validation

- All three pages updated; `grep -rn "Math.ceil(data.total / 20) : 0" manage_front/src/` returns no remaining occurrences.

@Mason-zy
